### PR TITLE
Fortran vs Numba: normal distribution performance experiments

### DIFF
--- a/normals.f90
+++ b/normals.f90
@@ -1,0 +1,37 @@
+program normals
+    implicit none
+
+    integer, parameter :: n = 100000000
+    integer, parameter :: blk = 1000000
+    real(8), dimension(blk) :: u1, u2
+    real(8) :: z_sq, sum1, sum2, mean, std_dev, pi
+    integer :: i, j, count_start, count_end, count_rate
+
+    pi = 4.0d0 * atan(1.0d0)
+
+    call system_clock(count_start, count_rate)
+
+    sum1 = 0.0d0
+    sum2 = 0.0d0
+
+    do i = 1, n / blk
+        call random_number(u1)
+        call random_number(u2)
+        do j = 1, blk
+            z_sq = (-2.0d0 * log(u1(j))) * cos(2.0d0 * pi * u2(j))**2
+            sum1 = sum1 + z_sq
+            sum2 = sum2 + z_sq * z_sq
+        end do
+    end do
+
+    mean = sum1 / n
+    std_dev = sqrt(sum2 / n - mean * mean)
+
+    call system_clock(count_end)
+
+    print '(A, F12.6)', 'Mean of squared normals:   ', mean
+    print '(A, F12.6)', 'Std dev of squared normals:', std_dev
+    print '(A, F10.4, A)', 'Time: ', &
+        real(count_end - count_start) / real(count_rate), ' seconds'
+
+end program normals

--- a/normals_numba.py
+++ b/normals_numba.py
@@ -1,0 +1,30 @@
+import numpy as np
+import numba as nb
+import time
+
+@nb.njit(fastmath=True)
+def normals_std(n):
+    sum1 = 0.0
+    sum2 = 0.0
+    for i in range(n):
+        z = np.random.randn()
+        z_sq = z * z
+        sum1 += z_sq
+        sum2 += z_sq * z_sq
+
+    mean = sum1 / n
+    std_dev = np.sqrt(sum2 / n - mean * mean)
+    return mean, std_dev
+
+n = 100_000_000
+
+# Warm up JIT
+normals_std(10)
+
+start = time.time()
+mean, std_dev = normals_std(n)
+elapsed = time.time() - start
+
+print(f"Mean of squared normals:    {mean:.6f}")
+print(f"Std dev of squared normals: {std_dev:.6f}")
+print(f"Time: {elapsed:.4f} seconds")


### PR DESCRIPTION
## Summary

- Add Fortran (`normals.f90`) and Numba (`normals_numba.py`) implementations that generate 100M standard normal random variates, square them, and compute the standard deviation of the squared values
- Both implementations were iteratively optimized, reducing execution time significantly from naive starting points
- Final results: Fortran ~1.58s, Numba ~1.48s

## Technical commentary: the optimization journey

### The task

Generate 100,000,000 standard normal random variates, square each one, and compute the standard deviation of the squared values. The expected results serve as a sanity check: squared standard normals follow a chi-squared(1) distribution, so the mean should be ~1.0 and the standard deviation should be ~√2 ≈ 1.4142.

### Fortran: from 2.70s → 1.58s

**Initial approach (2.70s):** The first version was written in idiomatic array-oriented Fortran — allocate four large arrays (`u1`, `u2`, `z`, `z_sq`), generate all uniforms at once via vectorized `random_number` calls, apply the Box-Muller transform across entire arrays, then compute `sum()` and `sum((z_sq - mean)**2)` for the standard deviation.

The problem: four arrays of 100M `real(8)` values = ~3.2 GB of memory. This causes heavy cache pressure, and the multi-pass approach (generate → transform → square → sum → subtract mean → square deviations → sum again) touches memory repeatedly with poor locality.

**Failed optimization — scalar loop (3.54s):** Switching to a fully scalar single-loop approach (generate two uniforms, Box-Muller, square, accumulate) was actually *slower*. The culprit: calling `random_number` on scalar values in a tight loop has significantly more call overhead than the vectorized batch version. Each scalar call has fixed overhead that dominates when the per-element work is small.

**Final approach — blocked single-pass (1.58s):** The winning strategy combines vectorized random number generation with single-pass accumulation. We generate uniforms in blocks of 1M (small enough to stay in L2/L3 cache), then loop through each block accumulating `sum(x)` and `sum(x²)`. The standard deviation is then computed via the well-known identity `σ = √(E[X²] - E[X]²)`, avoiding a second pass to subtract the mean. This gives us:

- **Vectorized RNG** — `random_number` on a 1M-element array amortizes call overhead
- **Cache-friendly blocking** — 1M × 8 bytes ≈ 8 MB fits comfortably in L3 cache, so the inner loop hits warm cache lines
- **Single-pass statistics** — accumulating `Σx` and `Σx²` simultaneously avoids storing the full z_sq array entirely, cutting memory from ~3.2 GB to ~16 MB (two 1M buffers)
- **No intermediate z array** — we fold the squaring directly into the Box-Muller output: `(-2 log u₁) · cos²(2πu₂)`

Compiled with `gfortran -O3`, which enables autovectorization, function inlining, and loop optimizations.

### Numba: from 2.05s → 1.48s

**Initial approach (2.05s):** The first version allocated a full 100M-element array, filled it with squared normals one at a time via `np.random.randn()`, then made two additional passes to compute mean and variance.

Three separate loops over 100M elements means three full traversals of an ~800 MB array. The array exists solely to enable the two-pass standard deviation calculation — first compute the mean, then compute deviations from the mean.

**Optimized approach (1.48s):** Two changes brought a ~28% speedup:

1. **`fastmath=True`** — This flag tells LLVM (Numba's backend compiler) it can assume IEEE 754 special cases (NaN propagation, signed zeros, infinities) don't need strict handling. This unlocks reordering of floating-point operations, fused multiply-add (FMA) instructions, and more aggressive SIMD vectorization. For statistical workloads where we don't care about NaN edge cases, this is essentially free performance.

2. **Single-pass accumulation** — Same mathematical trick as the Fortran version: accumulate `Σx` and `Σx²` in a single loop, then compute `σ = √(E[X²] - E[X]²)`. This eliminates the 800 MB array allocation entirely and replaces three loop passes with one. The working set drops to just two scalar accumulators, which live in registers.

### Why Numba edges out Fortran here

The Numba version is slightly faster (~1.48s vs ~1.58s) despite being Python. A few factors:

- **LLVM vs GCC backend** — Numba compiles through LLVM, while gfortran uses GCC. LLVM sometimes generates tighter code for simple numerical loops, particularly with `fastmath` enabling FMA and vectorization opportunities
- **RNG differences** — Numba and gfortran use different PRNG algorithms. Numba uses a variant of the Ziggurat algorithm for normal generation (via NumPy's RNG), which is faster than Box-Muller. The Fortran version must generate normals from uniforms via Box-Muller explicitly, paying for `log()` and `cos()` calls
- **Scalar vs blocked loop** — Numba's scalar loop with register accumulators has ideal data locality; the Fortran version still loops through 1M-element blocks with array indexing

### Key takeaways

1. **Memory allocation and cache pressure dominate** — the biggest wins in both languages came from eliminating large temporary arrays, not from algorithmic cleverness
2. **Single-pass statistics via `Var(X) = E[X²] - E[X]²`** is a simple but powerful optimization that halves memory traffic for standard deviation calculations
3. **Vectorized RNG matters in Fortran** — scalar `random_number` calls in a tight loop are surprisingly expensive; batching is essential
4. **Numba + `fastmath` is genuinely competitive with compiled Fortran** for this class of numerical workload

## Test plan

- [x] Verify both implementations produce mean ≈ 1.0 and std dev ≈ √2 (chi-squared(1) distribution)
- [x] Verify Fortran compiles cleanly with `gfortran -O3`
- [x] Verify Numba JIT warms up before timed run
- [x] Compare timings across optimization stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)